### PR TITLE
dumpstate: remote bug reports fail

### DIFF
--- a/cmds/dumpstate/dumpstate.cpp
+++ b/cmds/dumpstate/dumpstate.cpp
@@ -1577,6 +1577,7 @@ int main(int argc, char *argv[]) {
         } else if (ds.extra_options_ == "bugreportremote") {
             do_vibrate = 0;
             is_remote_mode = 1;
+            do_zip_file = 1;
             do_fb = 0;
         } else if (ds.extra_options_ == "bugreportwear") {
             ds.update_progress_ = true;


### PR DESCRIPTION
Call DevicePolicyManager.requestBugreport() in device owner,
the service 'bugreport' killed by signal 1.

Jira: None
Test: Call DevicePolicyManager.requestBugreport() in device owner,and get reports success.

Signed-off-by: xiangj5x <xiangjunx.jiang@intel.com>